### PR TITLE
Refactor NewCodeMigration and NewCodeMigrationCustom

### DIFF
--- a/migration_default.go
+++ b/migration_default.go
@@ -74,7 +74,9 @@ var CodeMigrationDateFormat = "20060102150405"
 //
 // It uses the `NewCodeMigrationCustom`.
 func NewCodeMigration(handlers ...Handler) *DefaultMigration {
-	return NewCodeMigrationCustom(1, handlers...)
+	m := NewCodeMigrationCustom(1, handlers...)
+	DefaultCodeSource().Register(m)
+	return m
 }
 
 // NewCodeMigrationCustom uses the regex to extract data NewMigration.
@@ -91,7 +93,6 @@ func NewCodeMigrationCustom(skip int, handlers ...Handler) *DefaultMigration {
 				panic(fmt.Sprintf("the file name '%s' has an invalid datetime", file))
 			}
 			m := NewMigration(id, groups[2], handlers...)
-			DefaultCodeSource().Register(m)
 			return m
 		}
 		panic(fmt.Sprintf("the file name '%s' has an invalid format", file))


### PR DESCRIPTION
In order to improve extensibility, `NewCodeMigrationCustom`
should not register the migration into `DefaultCodeSource`.

One should use `NewCodeMigrationCustom` to add migration to another
code source easily without needing to handle `runtime.Caller` or
parsing `CodeMigrationDateFormat`.

Example of what we should avoid:

```go
package migrate

import (
	"fmt"
	"path"
	"regexp"
	"runtime"
	"time"

	"github.com/lab259/go-migration"
)

var codeMigrationRegex = regexp.MustCompile("^([0-9]{4}[0-9]{2}[0-9]{2}[0-9]{2}[0-9]{2}[0-9]{2})_(.*).go$")

var tenantCodeSource *migration.CodeSource

func DefaultTenantCodeSource() *migration.CodeSource {
	if tenantCodeSource == nil {
		tenantCodeSource = migration.NewCodeSource()
	}
	return tenantCodeSource
}

// basically the same NewCodeMigrationCustom
func NewTenantCodeMigration(skip int, handlers ...migration.Handler) *migration.DefaultMigration {
	_, file, _, ok := runtime.Caller(1 + skip)
	if ok {
		groups := codeMigrationRegex.FindStringSubmatch(path.Base(file))
		if len(groups) == 3 {
			id, err := time.Parse(migration.CodeMigrationDateFormat, groups[1])
			if err != nil {
				panic(fmt.Sprintf("the file name '%s' has an invalid datetime", file))
			}
			m := migration.NewMigration(id, groups[2], handlers...)
			DefaultTenantCodeSource().Register(m) // changing the code source here
			return m
		}
		panic(fmt.Sprintf("the file name '%s' has an invalid format", file))
	} else {
		panic(fmt.Sprintf("the file name '%s' has an invalid format", file))
	}
}
```

... could easily be:

```go
package migrate

import (
	"github.com/lab259/go-migration"
)

var tenantCodeSource *migration.CodeSource

func DefaultTenantCodeSource() *migration.CodeSource {
	if tenantCodeSource == nil {
		tenantCodeSource = migration.NewCodeSource()
	}
	return tenantCodeSource
}

func NewTenantCodeMigration(handlers ...migration.Handler) *migration.DefaultMigration {
	m := migration.NewCodeMigrationCustom(1, handlers...)
	DefaultTenantCodeSource().Register(m)
	return m
}
```